### PR TITLE
chore: dedent dependency is not used

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,5 @@ gunicorn
 flask-httpauth
 flask
 flask-cors
-flask-restful 
+flask-restful
 flasgger
-dedent


### PR DESCRIPTION
It's already using [`textwrap.dedent`](https://docs.python.org/3/library/textwrap.html#textwrap.dedent) from the stdlib.

And also, very old. https://github.com/ctismer/dedent